### PR TITLE
Add tap dance, update caps word/caps lock behavior

### DIFF
--- a/keyboards/ergodox_ez/config.h
+++ b/keyboards/ergodox_ez/config.h
@@ -23,7 +23,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define ORYX_CONFIGURATOR
 
 // Caps Word
-#define BOTH_SHIFTS_TURNS_ON_CAPS_WORD
+// https://docs.qmk.fm/#/feature_caps_word
+//#define BOTH_SHIFTS_TURNS_ON_CAPS_WORD
+#define DOUBLE_TAP_SHIFT_TURNS_ON_CAPS_WORD
 
 /* key matrix size */
 #define MATRIX_ROWS 14

--- a/keyboards/ergodox_ez/keymaps/sdygert/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/sdygert/keymap.c
@@ -19,6 +19,18 @@ enum custom_keycodes {
 // #endif
 };
 
+// https://docs.qmk.fm/#/feature_tap_dance
+// Tap Dance declarations
+enum {
+    TD_RSFT_CAPS_L
+};
+
+// Tap Dance definitions
+tap_dance_action_t tap_dance_actions[] = {
+    // Tap once for Right Shift, twice for Caps Lock
+    [TD_RSFT_CAPS_L] = ACTION_TAP_DANCE_DOUBLE(KC_RSFT, KC_CAPS)
+};
+
 // clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 /* Keymap 0: Basic layer
@@ -29,8 +41,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * | Del    |   Q  |   W  |   E  |   R  |   T  |  L1  |           |  L2  |   Y  |   U  |   I  |   O  |   P  | \/F12  |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * | BkSp   |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |; / L2|' / Cmd |
- * |--------+------+------+------+------+------|      |           | Caps |------+------+------+------+------+--------|
- * | LShift |Z/Ctrl|X/Alt |C/Shft|   V  |   B  |      |           |      |   N  |   M  |,/Shft|./Alt |//Ctrl| RShift |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |LShft/CW|Z/Ctrl|X/Alt |C/Shft|   V  |   B  |      |           |      |   N  |   M  |,/Shft|./Alt |//Ctrl|RShft/CL|
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
  *   |   =  |PrtScn|      | Left | Right|                                       |  Up  | Down |   [  |   ]  |  L3  |
  *   `----------------------------------'                                       `----------------------------------'
@@ -47,7 +59,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_GRV,   LT(0,KC_1),     LT(0,KC_2),     LT(0,KC_3),     LT(0,KC_4),     LT(0,KC_5),     KC_LEFT,              KC_RGHT,  LT(0,KC_6),     LT(0,KC_7),     LT(0,KC_8),     LT(0,KC_9),        LT(0,KC_0),        LT(0,KC_MINS),
   KC_DEL,   KC_Q,           KC_W,           KC_E,           KC_R,           KC_T,           TG(SYMB),             TG(MDIA), KC_Y,           KC_U,           KC_I,           KC_O,              KC_P,              LT(0,KC_BSLS),
   KC_BSPC,  KC_A,           KC_S,           KC_D,           KC_F,           KC_G,                                           KC_H,           KC_J,           KC_K,           KC_L,              LT(MDIA, KC_SCLN), GUI_T(KC_QUOT),
-  KC_LSFT,  CTL_T(KC_Z),    ALT_T(KC_X),    SFT_T(KC_C),    KC_V,           KC_B,           KC_NO,                KC_CAPS,  KC_N,           KC_M,           SFT_T(KC_COMM), ALT_T(KC_DOT),     CTL_T(KC_SLSH),    KC_RSFT,
+  KC_LSFT,  CTL_T(KC_Z),    ALT_T(KC_X),    SFT_T(KC_C),    KC_V,           KC_B,           KC_NO,                KC_NO,    KC_N,           KC_M,           SFT_T(KC_COMM), ALT_T(KC_DOT),     CTL_T(KC_SLSH),    TD(TD_RSFT_CAPS_L),
   KC_EQL,   KC_PSCR,        KC_NO,          KC_LEFT,        KC_RGHT,                                                        KC_UP,          KC_DOWN,        KC_LBRC,        KC_RBRC,           TG(GAME),
                                                                             ALT_T(KC_APP),  KC_LGUI,              KC_LALT,  CTL_T(KC_ESC),
                                                                                             KC_HOME,              KC_PGUP,

--- a/keyboards/ergodox_ez/rules.mk
+++ b/keyboards/ergodox_ez/rules.mk
@@ -19,7 +19,8 @@ UNICODE_ENABLE   = no   # Unicode
 SWAP_HANDS_ENABLE= no   # Allow swapping hands of keyboard
 
 KEY_LOCK_ENABLE = yes   # Enable Key Lock
-CAPS_WORD_ENABLE= yes	# Enable Caps Word
+CAPS_WORD_ENABLE= yes	# Enable Caps Word https://docs.qmk.fm/#/feature_caps_word
+TAP_DANCE_ENABLE= yes	# Enable tap dance https://docs.qmk.fm/#/feature_tap_dance
 
 RGB_MATRIX_ENABLE = no # Enable Glow
 RGB_MATRIX_DRIVER = IS31FL3731


### PR DESCRIPTION
Add tap dance functionality and so that right shift can take over for a
dedicated caps lock key which has not been removed.

Update caps word so that both shifts are no longer used as the trigger.